### PR TITLE
feat: catch case for empty assets folder

### DIFF
--- a/arweave.ts
+++ b/arweave.ts
@@ -187,6 +187,11 @@ export const processCliUpload = async (answers: any) => {
 
     let files = fs.readdirSync("./assets").filter((file) => file.endsWith(".json"))
 
+    if (files.length === 0) {
+        spinner.fail("No files found in assets folder")
+        return
+    }
+
     //validate images
     for (let file of files) {
         try {


### PR DESCRIPTION
Hello,

I just ran the cli to see what happens and was surprised that it successfully validated on an empty folder. I added an error message for this case.